### PR TITLE
Remove deprecated images.domains config

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -11,7 +11,6 @@ module.exports = {
         pathname: '/images/user-photos/**',
       },
     ],
-    domains: ['img.booka.life'],
     dangerouslyAllowSVG: true,
     contentSecurityPolicy: "default-src 'self'; script-src 'none'; sandbox;",
     // Улучшенная обработка внешних изображений


### PR DESCRIPTION
## Summary
- Remove deprecated `images.domains` from `next.config.js` — `remotePatterns` already covers this

## Test plan
- [ ] Verify images from `img.booka.life` still load correctly after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)