### PR TITLE
Интеграция чат-модалки с Элли и Partner API

### DIFF
--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/types/routes.d.ts";
+import "./.next/dev/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/pages/api-reference/config/typescript for more information.

--- a/src/api/partnerApi.ts
+++ b/src/api/partnerApi.ts
@@ -1,0 +1,102 @@
+/**
+ * Partner API client — проксируется через /api/partner/ чтобы не светить ключ.
+ */
+
+const BASE = '/api/partner';
+
+async function partnerGet<T>(path: string, signal?: AbortSignal): Promise<T> {
+  const response = await fetch(`${BASE}/${path}`, {
+    headers: { 'Accept-Language': 'ru' },
+    signal,
+  });
+  if (!response.ok) {
+    throw new Error(`Partner API ${path}: ${response.status}`);
+  }
+  return response.json();
+}
+
+async function partnerPost<T>(path: string, body: Record<string, unknown>, signal?: AbortSignal): Promise<T> {
+  const response = await fetch(`${BASE}/${path}`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json', 'Accept-Language': 'ru' },
+    body: JSON.stringify(body),
+    signal,
+  });
+  if (!response.ok) {
+    const data = await response.json().catch(() => ({ error: `Error ${response.status}` }));
+    throw new Error(data.error || data.message || `Partner API ${path}: ${response.status}`);
+  }
+  return response.json();
+}
+
+// --- Types ---
+
+export interface PartnerMaster {
+  id: string;
+  name: string;
+  speciality: string;
+  rating: number;
+  experience: number;
+  consultationFormat: string | null;
+  isLgbtFriendly: boolean | null;
+  aboutMe: string;
+  address: string | null;
+  slug: string;
+  services: PartnerService[];
+}
+
+export interface PartnerService {
+  id: string;
+  name: string;
+  price: number;
+  duration: number;
+  currencyCode: string;
+}
+
+export interface PartnerSlotsResponse {
+  code: number;
+  data: Record<string, string[]>;
+}
+
+export interface PartnerBookingResponse {
+  code: number;
+  data: {
+    bookingId: string;
+    status: string;
+    masterName: string;
+    appointmentDate: string;
+    startTime: string;
+    endTime: string;
+    address: string | null;
+    meetingLink: string | null;
+  };
+}
+
+// --- Functions ---
+
+export async function getPartnerMasters(signal?: AbortSignal) {
+  return partnerGet<{ code: number; data: PartnerMaster[]; pagination: { total: number } }>('masters?pageSize=50', signal);
+}
+
+export async function getPartnerMasterSlots(masterId: string, date: string, days = 7, signal?: AbortSignal) {
+  return partnerGet<PartnerSlotsResponse>(
+    `masters/${encodeURIComponent(masterId)}/slots?date=${encodeURIComponent(date)}&days=${days}`,
+    signal,
+  );
+}
+
+export async function createPartnerBooking(
+  booking: {
+    masterId: string;
+    serviceIds: string[];
+    appointmentDate: string;
+    startTime: string;
+    endTime: string;
+    clientName: string;
+    clientPhone: string;
+    note?: string;
+  },
+  signal?: AbortSignal,
+) {
+  return partnerPost<PartnerBookingResponse>('bookings', booking, signal);
+}

--- a/src/components/ChatModal.tsx
+++ b/src/components/ChatModal.tsx
@@ -1,0 +1,574 @@
+'use client';
+
+import { useState, useEffect, useRef, useCallback } from 'react';
+import Link from 'next/link';
+import ReactMarkdown from 'react-markdown';
+import { signalRService } from '../api/signalRService';
+import {
+  startMatching,
+  sendMessage,
+  type MessageHistoryItem,
+  type PsychologistSuggestion,
+  type BookingSuggestion,
+  normalizePhone
+} from '../api/psychologistMatchApi';
+import { createPartnerBooking, getPartnerMasterSlots } from '../api/partnerApi';
+
+interface Message {
+  id: string;
+  text: string;
+  sender: 'assistant' | 'user';
+  psychologistSuggestions?: PsychologistSuggestion[];
+  bookingSuggestion?: BookingSuggestion;
+}
+
+interface ChatModalProps {
+  open: boolean;
+  onClose: () => void;
+}
+
+const ChatModal = ({ open, onClose }: ChatModalProps) => {
+  const [messages, setMessages] = useState<Message[]>([]);
+  const [inputText, setInputText] = useState('');
+  const [isLoading, setIsLoading] = useState(false);
+  const [sessionId, setSessionId] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [currentStreamingMessage, setCurrentStreamingMessage] = useState<string>('');
+  const [currentStreamingMessageId, setCurrentStreamingMessageId] = useState<string | null>(null);
+  const messagesContainerRef = useRef<HTMLDivElement>(null);
+  const messagesEndRef = useRef<HTMLDivElement>(null);
+  const inputRef = useRef<HTMLTextAreaElement>(null);
+  const isInitialized = useRef(false);
+  const isUsingSignalR = useRef(false);
+  const mountedRef = useRef(true);
+  const timersRef = useRef<ReturnType<typeof setTimeout>[]>([]);
+  const abortControllerRef = useRef<AbortController | null>(null);
+
+  const handleMessageChunkRef = useRef<(data: { chunk: string }) => void>(() => {});
+  const handleMessageCompleteRef = useRef<(data: {
+    message: string;
+    sessionId: string;
+    psychologistSuggestions?: PsychologistSuggestion[];
+    bookingSuggestion?: BookingSuggestion;
+  }) => void>(() => {});
+  const handleErrorRef = useRef<(error: { message: string }) => void>(() => {});
+
+  const safeTimeout = useCallback((fn: () => void, ms: number) => {
+    const id = setTimeout(fn, ms);
+    timersRef.current.push(id);
+    return id;
+  }, []);
+
+  // Инициализация при открытии
+  useEffect(() => {
+    if (!open) return;
+    mountedRef.current = true;
+
+    if (!isInitialized.current) {
+      isInitialized.current = true;
+      initializeSession();
+    }
+
+    safeTimeout(() => inputRef.current?.focus(), 100);
+
+    return () => {
+      // Не сбрасываем при закрытии — сохраняем сессию
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [open]);
+
+  // Cleanup при unmount
+  useEffect(() => {
+    return () => {
+      mountedRef.current = false;
+      timersRef.current.forEach(clearTimeout);
+      timersRef.current = [];
+      abortControllerRef.current?.abort();
+
+      if (isUsingSignalR.current) {
+        signalRService.offMessageChunk(handleMessageChunkRef.current);
+        signalRService.offMessageComplete(handleMessageCompleteRef.current);
+        signalRService.offError(handleErrorRef.current);
+        signalRService.disconnect();
+        isUsingSignalR.current = false;
+      }
+    };
+  }, []);
+
+  // ESC для закрытия
+  useEffect(() => {
+    if (!open) return;
+    const handleEsc = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') onClose();
+    };
+    document.addEventListener('keydown', handleEsc);
+    return () => document.removeEventListener('keydown', handleEsc);
+  }, [open, onClose]);
+
+  // Скролл при новых сообщениях
+  useEffect(() => {
+    if (messagesContainerRef.current) {
+      requestAnimationFrame(() => {
+        if (messagesContainerRef.current) {
+          messagesContainerRef.current.scrollTop = messagesContainerRef.current.scrollHeight;
+        }
+      });
+    }
+  }, [messages, isLoading, currentStreamingMessage]);
+
+  const setupSignalRListeners = () => {
+    const handleMessageChunk = (data: { chunk: string }) => {
+      if (!mountedRef.current) return;
+      setCurrentStreamingMessageId(prev => {
+        if (!prev) {
+          const id = `modal-welcome-${Date.now()}`;
+          setCurrentStreamingMessage(data.chunk);
+          setMessages(msgs => msgs.length === 0 ? [{ id, text: '', sender: 'assistant' }] : msgs);
+          return id;
+        }
+        setCurrentStreamingMessage(p => p + data.chunk);
+        return prev;
+      });
+      requestAnimationFrame(() => {
+        if (messagesContainerRef.current) {
+          messagesContainerRef.current.scrollTop = messagesContainerRef.current.scrollHeight;
+        }
+      });
+    };
+
+    const handleMessageComplete = (data: {
+      message: string;
+      sessionId: string;
+      psychologistSuggestions?: PsychologistSuggestion[];
+      bookingSuggestion?: BookingSuggestion;
+    }) => {
+      if (!mountedRef.current) return;
+      setIsLoading(false);
+      setCurrentStreamingMessageId(prevId => {
+        const msg: Message = {
+          id: prevId || `modal-assistant-${Date.now()}`,
+          text: data.message,
+          sender: 'assistant',
+          psychologistSuggestions: data.psychologistSuggestions,
+          bookingSuggestion: data.bookingSuggestion,
+        };
+        setMessages(prev => [...prev.filter(m => m.id !== prevId), msg]);
+        return null;
+      });
+      setCurrentStreamingMessage('');
+      setSessionId(data.sessionId);
+
+      if (data.bookingSuggestion?.masterId && data.bookingSuggestion?.serviceIds &&
+          data.bookingSuggestion?.suggestedDate && data.bookingSuggestion?.suggestedTime &&
+          data.bookingSuggestion?.clientName && data.bookingSuggestion?.clientPhone) {
+        handleCreateBooking(data.bookingSuggestion);
+      }
+      safeTimeout(() => inputRef.current?.focus(), 100);
+    };
+
+    const handleError = (err: { message: string }) => {
+      if (!mountedRef.current) return;
+      setIsLoading(false);
+      setCurrentStreamingMessage('');
+      setError(err.message);
+      setCurrentStreamingMessageId(prevId => {
+        setMessages(prev => [
+          ...prev.filter(m => m.id !== prevId),
+          { id: `modal-error-${Date.now()}`, text: `Извините, произошла ошибка: ${err.message}`, sender: 'assistant' },
+        ]);
+        return null;
+      });
+      safeTimeout(() => inputRef.current?.focus(), 100);
+    };
+
+    handleMessageChunkRef.current = handleMessageChunk;
+    handleMessageCompleteRef.current = handleMessageComplete;
+    handleErrorRef.current = handleError;
+
+    signalRService.onMessageChunk(handleMessageChunk);
+    signalRService.onMessageComplete(handleMessageComplete);
+    signalRService.onError(handleError);
+  };
+
+  const initializeSession = async () => {
+    const controller = new AbortController();
+    abortControllerRef.current = controller;
+
+    try {
+      setIsLoading(true);
+      const useRestOnly = process.env.NEXT_PUBLIC_USE_REST_ONLY === 'true';
+
+      try {
+        if (useRestOnly) throw new Error('REST only mode');
+        await signalRService.connect();
+        isUsingSignalR.current = true;
+        setupSignalRListeners();
+        await signalRService.startMatching();
+      } catch {
+        isUsingSignalR.current = false;
+        await signalRService.disconnect();
+
+        const response = await startMatching(undefined, controller.signal);
+        if (!mountedRef.current) return;
+
+        if (response.code === 200 && response.message) {
+          setSessionId(response.message.sessionId);
+          setMessages([{
+            id: `modal-welcome-${Date.now()}`,
+            text: response.message.message,
+            sender: 'assistant',
+          }]);
+        }
+      }
+    } catch (err) {
+      if (!mountedRef.current) return;
+      if (err instanceof DOMException && err.name === 'AbortError') return;
+      setError('Не удалось подключиться к серверу.');
+      setMessages([{
+        id: `modal-fallback-${Date.now()}`,
+        text: 'Привет! Я помогу тебе подобрать подходящего психолога. Расскажи, с какой ситуацией или проблемой ты хочешь обратиться?',
+        sender: 'assistant',
+      }]);
+    } finally {
+      if (mountedRef.current) {
+        setIsLoading(false);
+        inputRef.current?.focus();
+      }
+    }
+  };
+
+  const validateInput = (text: string): string | null => {
+    const trimmed = text.trim();
+    if (trimmed.length === 0) return 'Пожалуйста, введите сообщение';
+    if (trimmed.length < 3) return 'Сообщение слишком короткое (минимум 3 символа)';
+    if (trimmed.length > 1000) return 'Сообщение слишком длинное (максимум 1000 символов)';
+    return null;
+  };
+
+  const getMessageHistory = (): MessageHistoryItem[] => {
+    return messages.map(msg => ({
+      role: msg.sender === 'user' ? 'user' : 'assistant',
+      content: msg.text,
+      timestamp: new Date().toISOString(),
+    }));
+  };
+
+  const handleSend = async () => {
+    if (isLoading) return;
+    const validationError = validateInput(inputText);
+    if (validationError) {
+      setError(validationError);
+      safeTimeout(() => setError(null), 3000);
+      return;
+    }
+
+    setError(null);
+    const userMessage: Message = { id: `modal-user-${Date.now()}`, text: inputText.trim(), sender: 'user' };
+    setMessages(prev => [...prev, userMessage]);
+    const messageText = inputText.trim();
+    setInputText('');
+    setIsLoading(true);
+
+    const streamingId = `modal-streaming-${Date.now()}`;
+    setCurrentStreamingMessageId(streamingId);
+    setCurrentStreamingMessage('');
+    setMessages(prev => [...prev, { id: streamingId, text: '', sender: 'assistant' }]);
+
+    const controller = new AbortController();
+    abortControllerRef.current = controller;
+
+    try {
+      if (isUsingSignalR.current && signalRService.isConnected()) {
+        await signalRService.sendMessage(messageText, getMessageHistory());
+      } else {
+        const response = await sendMessage(messageText, sessionId || undefined, undefined, getMessageHistory(), controller.signal);
+        if (!mountedRef.current) return;
+
+        if (response.code === 200 && response.message) {
+          setMessages(prev => prev.filter(m => m.id !== streamingId));
+          setCurrentStreamingMessageId(null);
+          setCurrentStreamingMessage('');
+
+          const assistantMsg: Message = {
+            id: `modal-assistant-${Date.now()}`,
+            text: response.message.message,
+            sender: 'assistant',
+            psychologistSuggestions: response.message.psychologistSuggestions,
+            bookingSuggestion: response.message.bookingSuggestion,
+          };
+
+          if (response.message.sessionId) setSessionId(response.message.sessionId);
+          setMessages(prev => [...prev, assistantMsg]);
+
+          if (response.message.bookingSuggestion?.masterId && response.message.bookingSuggestion?.serviceIds &&
+              response.message.bookingSuggestion?.suggestedDate && response.message.bookingSuggestion?.suggestedTime &&
+              response.message.bookingSuggestion?.clientName && response.message.bookingSuggestion?.clientPhone) {
+            await handleCreateBooking(response.message.bookingSuggestion);
+          }
+          setIsLoading(false);
+        }
+      }
+    } catch (err: unknown) {
+      if (!mountedRef.current) return;
+      if (err instanceof DOMException && err.name === 'AbortError') return;
+      const errorText = err instanceof Error ? err.message : 'Не удалось отправить сообщение.';
+      setError(errorText);
+      setMessages(prev => prev.filter(m => m.id !== streamingId));
+      setCurrentStreamingMessageId(null);
+      setCurrentStreamingMessage('');
+      setMessages(prev => [...prev, { id: `modal-error-${Date.now()}`, text: `Ошибка: ${errorText}`, sender: 'assistant' }]);
+      setIsLoading(false);
+    }
+  };
+
+  const handleCreateBooking = async (bs: BookingSuggestion) => {
+    if (!bs.masterId || !bs.serviceIds || !bs.suggestedDate || !bs.suggestedTime || !bs.clientName || !bs.clientPhone) return;
+    try {
+      setIsLoading(true);
+      const start = new Date(`${bs.suggestedDate}T${bs.suggestedTime}`);
+      const end = new Date(start.getTime() + 60 * 60000);
+      const endTime = `${String(end.getHours()).padStart(2, '0')}:${String(end.getMinutes()).padStart(2, '0')}:00`;
+
+      const res = await createPartnerBooking({
+        masterId: bs.masterId,
+        serviceIds: bs.serviceIds,
+        appointmentDate: bs.suggestedDate,
+        startTime: bs.suggestedTime,
+        endTime,
+        clientName: bs.clientName,
+        clientPhone: normalizePhone(bs.clientPhone),
+        note: bs.note,
+      });
+
+      if (res.code === 200) {
+        const d = res.data;
+        let confirmText = `Запись подтверждена! Вы записаны к ${d.masterName} на ${d.appointmentDate} в ${d.startTime}.`;
+        if (d.address) confirmText += `\n\nАдрес: ${d.address}`;
+        if (d.meetingLink) confirmText += `\n\nСсылка на встречу: ${d.meetingLink}`;
+        confirmText += '\n\nДля подтверждения записи необходимо внести оплату:\nНомер счета: 1030120001878394\nПолучатель: ОсОО «Живи Легко»\n\nПри отмене менее чем за сутки оплата не возвращается.';
+
+        setMessages(prev => [...prev, {
+          id: `modal-booking-${Date.now()}`,
+          text: confirmText,
+          sender: 'assistant',
+        }]);
+      }
+    } catch (err: unknown) {
+      const errMsg = err instanceof Error ? err.message : 'Ошибка';
+      if (errMsg.includes('409') || errMsg.toLowerCase().includes('занят')) {
+        setMessages(prev => [...prev, {
+          id: `modal-booking-err-${Date.now()}`,
+          text: 'К сожалению, этот слот уже занят. Попробуйте выбрать другое время.',
+          sender: 'assistant',
+        }]);
+      } else {
+        setMessages(prev => [...prev, {
+          id: `modal-booking-err-${Date.now()}`,
+          text: `Не удалось создать запись: ${errMsg}. Попробуйте ещё раз.`,
+          sender: 'assistant',
+        }]);
+      }
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  const handleShowSlots = async (psychologistId: string, psychologistName: string) => {
+    try {
+      setIsLoading(true);
+      const today = new Date().toISOString().split('T')[0];
+      const res = await getPartnerMasterSlots(psychologistId, today, 7);
+
+      if (res.code === 200 && res.data) {
+        const days = Object.entries(res.data).filter(([, slots]) => slots.length > 0);
+        if (days.length === 0) {
+          setMessages(prev => [...prev, {
+            id: `modal-slots-${Date.now()}`,
+            text: `К сожалению, у ${psychologistName} нет свободных окошек на ближайшую неделю. Попробуйте выбрать другого специалиста.`,
+            sender: 'assistant',
+          }]);
+        } else {
+          const slotsText = days.map(([date, slots]) => {
+            const d = new Date(date);
+            const dayName = d.toLocaleDateString('ru-RU', { weekday: 'short', day: 'numeric', month: 'short' });
+            return `**${dayName}**: ${slots.join(', ')}`;
+          }).join('\n');
+
+          setMessages(prev => [...prev, {
+            id: `modal-slots-${Date.now()}`,
+            text: `Свободные окошки у ${psychologistName}:\n\n${slotsText}\n\nНапишите удобное время, и я запишу вас.`,
+            sender: 'assistant',
+          }]);
+        }
+      }
+    } catch {
+      setMessages(prev => [...prev, {
+        id: `modal-slots-err-${Date.now()}`,
+        text: 'Не удалось загрузить расписание. Попробуйте позже.',
+        sender: 'assistant',
+      }]);
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  const handleKeyPress = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
+    if (e.key === 'Enter' && !e.shiftKey) {
+      e.preventDefault();
+      handleSend();
+    }
+  };
+
+  if (!open) return null;
+
+  return (
+    <div className="chat-modal-overlay" onClick={onClose}>
+      <div className="chat-modal-window" onClick={e => e.stopPropagation()} role="dialog" aria-modal="true" aria-label="Чат с Элли">
+        {/* Header */}
+        <div className="chat-modal-header">
+          <div className="chat-header__info">
+            <div className="chat-header__avatar" aria-hidden="true">
+              <i className="fas fa-robot"></i>
+            </div>
+            <div>
+              <h2 className="chat-header__title">Элли</h2>
+              <p className="chat-header__status">{isLoading ? 'печатает...' : 'онлайн'}</p>
+            </div>
+          </div>
+          <button className="chat-modal-close" onClick={onClose} aria-label="Закрыть" type="button">
+            <i className="fas fa-times"></i>
+          </button>
+        </div>
+
+        {/* Messages */}
+        <div className="chat-modal-messages" ref={messagesContainerRef} role="log" aria-live="polite">
+          {messages.map(message => {
+            const isStreaming = message.id === currentStreamingMessageId;
+            const displayText = isStreaming ? currentStreamingMessage : message.text;
+
+            return (
+              <div key={message.id}>
+                <div className={`chat-message chat-message--${message.sender}`}>
+                  <div className="chat-message__bubble">
+                    {message.sender === 'assistant' ? (
+                      <>
+                        <ReactMarkdown
+                          components={{
+                            p: ({ children }) => <p className="markdown-paragraph">{children}</p>,
+                            ul: ({ children }) => <ul className="markdown-list">{children}</ul>,
+                            ol: ({ children }) => <ol className="markdown-list markdown-list--numbered">{children}</ol>,
+                            li: ({ children }) => <li className="markdown-list-item">{children}</li>,
+                            strong: ({ children }) => <strong className="markdown-strong">{children}</strong>,
+                            em: ({ children }) => <em className="markdown-em">{children}</em>,
+                          }}
+                        >
+                          {displayText || (isStreaming ? '' : message.text)}
+                        </ReactMarkdown>
+                        {isStreaming && <span className="typing-cursor">|</span>}
+                      </>
+                    ) : (
+                      message.text
+                    )}
+                  </div>
+                </div>
+
+                {message.psychologistSuggestions && message.psychologistSuggestions.length > 0 && (
+                  <div className="psychologist-suggestions">
+                    <h3 className="suggestions-title">Рекомендуемые психологи:</h3>
+                    {message.psychologistSuggestions.map(p => (
+                      <div key={p.psychologistId} className="psychologist-card">
+                        <div className="psychologist-card__header">
+                          <h4 className="psychologist-card__name">{p.name}</h4>
+                          <div className="psychologist-card__rating">
+                            <i className="fas fa-star"></i>
+                            <span>{p.rating}</span>
+                          </div>
+                        </div>
+                        <p className="psychologist-card__speciality">{p.speciality}</p>
+                        {p.reason && <p className="psychologist-card__reason">{p.reason}</p>}
+                        <div className="psychologist-card__info">
+                          <span>Опыт: {p.experience} лет</span>
+                          <span>Клиентов: {p.numberOfClients}</span>
+                        </div>
+                        {p.services.length > 0 && (
+                          <div className="psychologist-card__services">
+                            {p.services.map(s => (
+                              <div key={s.serviceId} className="service-item">
+                                <span className="service-name">{s.serviceName}</span>
+                                <span className="service-price">{s.price} сом</span>
+                                <span className="service-duration">{s.durationMinutes} мин</span>
+                              </div>
+                            ))}
+                          </div>
+                        )}
+                        <div className="psychologist-card__actions">
+                          <button
+                            type="button"
+                            className="psychologist-card__slots-btn"
+                            onClick={() => handleShowSlots(p.psychologistId, p.name)}
+                            disabled={isLoading}
+                          >
+                            <i className="fas fa-calendar-alt"></i> Показать слоты
+                          </button>
+                          <Link href={`/staff?psychologist=${p.psychologistId}`} className="psychologist-card__link" onClick={onClose}>
+                            Посмотреть профиль <i className="fas fa-arrow-right"></i>
+                          </Link>
+                        </div>
+                      </div>
+                    ))}
+                  </div>
+                )}
+              </div>
+            );
+          })}
+
+          {isLoading && !currentStreamingMessageId && (
+            <div className="chat-message chat-message--assistant">
+              <div className="chat-message__bubble">
+                <div className="typing-indicator">
+                  <span></span><span></span><span></span>
+                </div>
+              </div>
+            </div>
+          )}
+          <div ref={messagesEndRef} />
+        </div>
+
+        {/* Input */}
+        <div className="chat-modal-input">
+          {error && (
+            <div className="chat-input-error" role="alert">
+              <i className="fas fa-exclamation-circle"></i>
+              <span>{error}</span>
+            </div>
+          )}
+          <div className="chat-modal-input-wrapper">
+            <textarea
+              ref={inputRef}
+              className="chat-modal-textarea"
+              value={inputText}
+              onChange={e => { setInputText(e.target.value); if (error) setError(null); }}
+              onKeyPress={handleKeyPress}
+              placeholder="Опишите вашу ситуацию..."
+              rows={2}
+              disabled={isLoading}
+              aria-label="Поле ввода сообщения"
+              maxLength={1000}
+            />
+            <button
+              className="chat-modal-send"
+              onClick={handleSend}
+              disabled={!inputText.trim() || isLoading}
+              aria-label="Отправить сообщение"
+              type="button"
+            >
+              <i className="fas fa-paper-plane" aria-hidden="true"></i>
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default ChatModal;

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -137,19 +137,26 @@ const Header = () => {
                         </li>
                     </ul>
                     <div className="nav__mobile-actions">
-                        <Link
-                            href="/staff"
+                        <button
+                            type="button"
                             className="btn btn--primary"
-                            onClick={closeMobileMenu}
+                            onClick={() => {
+                                closeMobileMenu();
+                                window.dispatchEvent(new Event('openChatModal'));
+                            }}
                         >
                             Подобрать психолога
-                        </Link>
+                        </button>
                     </div>
                 </div>
                 <div className="nav__actions">
-                    <Link href="/staff" className="btn btn--primary">
+                    <button
+                        type="button"
+                        className="btn btn--primary"
+                        onClick={() => window.dispatchEvent(new Event('openChatModal'))}
+                    >
                         Подобрать психолога
-                    </Link>
+                    </button>
                 </div>
                 <button
                     ref={toggleRef}

--- a/src/components/StaffHeader.tsx
+++ b/src/components/StaffHeader.tsx
@@ -88,6 +88,16 @@ const StaffHeader = () => {
             </li>
           </ul>
           <div className="nav__mobile-actions">
+            <button
+              type="button"
+              className="btn btn--primary"
+              onClick={() => {
+                closeMobileMenu();
+                window.dispatchEvent(new Event('openChatModal'));
+              }}
+            >
+              Подобрать психолога
+            </button>
             <Link href="/" className="btn btn--secondary" onClick={closeMobileMenu}>
               <i className="fas fa-arrow-left"></i>
               На главную
@@ -96,6 +106,13 @@ const StaffHeader = () => {
         </div>
 
         <div className="nav__actions">
+          <button
+            type="button"
+            className="btn btn--primary"
+            onClick={() => window.dispatchEvent(new Event('openChatModal'))}
+          >
+            Подобрать психолога
+          </button>
           <Link href="/" className="btn btn--secondary">
             <i className="fas fa-arrow-left"></i>
             На главную

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -6,6 +6,7 @@ import { useEffect, useState } from 'react';
 
 const PrivacyPolicyModal = dynamic(() => import('../components/PrivacyPolicyModal'), { ssr: false });
 const TermsOfUseModal = dynamic(() => import('../components/TermsOfUseModal'), { ssr: false });
+const ChatModal = dynamic(() => import('../components/ChatModal'), { ssr: false });
 
 const privacyPolicy = (
   <p>
@@ -114,15 +115,19 @@ const termsOfUse = (
 export default function App({ Component, pageProps }: AppProps) {
   const [showPrivacyModal, setShowPrivacyModal] = useState(false);
   const [showTermsModal, setShowTermsModal] = useState(false);
+  const [showChatModal, setShowChatModal] = useState(false);
 
   useEffect(() => {
     const openPrivacy = () => setShowPrivacyModal(true);
     const openTerms = () => setShowTermsModal(true);
+    const openChat = () => setShowChatModal(true);
     window.addEventListener('openPrivacyPolicyModal', openPrivacy);
     window.addEventListener('openTermsOfUseModal', openTerms);
+    window.addEventListener('openChatModal', openChat);
     return () => {
       window.removeEventListener('openPrivacyPolicyModal', openPrivacy);
       window.removeEventListener('openTermsOfUseModal', openTerms);
+      window.removeEventListener('openChatModal', openChat);
     };
   }, []);
 
@@ -158,6 +163,10 @@ export default function App({ Component, pageProps }: AppProps) {
         open={showTermsModal}
         onClose={() => setShowTermsModal(false)}
         termsText={termsOfUse}
+      />
+      <ChatModal
+        open={showChatModal}
+        onClose={() => setShowChatModal(false)}
       />
     </>
   );

--- a/src/pages/api/partner/[...path].ts
+++ b/src/pages/api/partner/[...path].ts
@@ -1,0 +1,58 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+
+const PARTNER_API_KEY = process.env.PARTNER_API_KEY;
+const BASE_URL = 'https://api.booka.life/api/partner/v1';
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (!PARTNER_API_KEY) {
+    return res.status(500).json({ error: 'Partner API key not configured' });
+  }
+
+  const { path } = req.query;
+  const pathStr = Array.isArray(path) ? path.join('/') : path || '';
+
+  // Разрешаем только безопасные пути
+  if (!/^[a-zA-Z0-9\-_/]+$/.test(pathStr)) {
+    return res.status(400).json({ error: 'Invalid path' });
+  }
+
+  const url = new URL(`${BASE_URL}/${pathStr}`);
+
+  // Прокидываем query-параметры (кроме path)
+  for (const [key, value] of Object.entries(req.query)) {
+    if (key === 'path') continue;
+    if (typeof value === 'string') {
+      url.searchParams.set(key, value);
+    }
+  }
+
+  try {
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), 15000);
+
+    const fetchOptions: RequestInit = {
+      method: req.method || 'GET',
+      headers: {
+        'X-API-Key': PARTNER_API_KEY,
+        'Accept-Language': 'ru',
+        'Content-Type': 'application/json',
+      },
+      signal: controller.signal,
+    };
+
+    if (req.method === 'POST' && req.body) {
+      fetchOptions.body = JSON.stringify(req.body);
+    }
+
+    const response = await fetch(url.toString(), fetchOptions);
+    clearTimeout(timeout);
+
+    const data = await response.json().catch(() => null);
+    return res.status(response.status).json(data || { error: 'Empty response' });
+  } catch (err) {
+    if (err instanceof DOMException && err.name === 'AbortError') {
+      return res.status(504).json({ error: 'Partner API timeout' });
+    }
+    return res.status(502).json({ error: 'Partner API unavailable' });
+  }
+}

--- a/src/styles/style.css
+++ b/src/styles/style.css
@@ -7305,6 +7305,179 @@ select:focus-visible {
   outline-offset: 2px;
 }
 
+/* === COMPONENT: ChatModal === */
+.chat-modal-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.5);
+  backdrop-filter: blur(4px);
+  -webkit-backdrop-filter: blur(4px);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 9999;
+  padding: 16px;
+}
+
+.chat-modal-window {
+  background: var(--bg-main);
+  border-radius: var(--radius-xl);
+  width: 100%;
+  max-width: 560px;
+  height: 80vh;
+  max-height: 700px;
+  display: flex;
+  flex-direction: column;
+  box-shadow: var(--shadow-xl);
+  overflow: hidden;
+}
+
+.chat-modal-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 16px 20px;
+  border-bottom: 1px solid var(--border-light);
+  background: var(--bg-main);
+}
+
+.chat-modal-close {
+  width: 36px;
+  height: 36px;
+  border: none;
+  background: rgba(0, 0, 0, 0.05);
+  border-radius: 50%;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 16px;
+  color: var(--text-secondary);
+  transition: background var(--transition-fast);
+}
+
+.chat-modal-close:hover {
+  background: rgba(0, 0, 0, 0.1);
+}
+
+.chat-modal-messages {
+  flex: 1;
+  overflow-y: auto;
+  padding: 16px 20px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.chat-modal-input {
+  border-top: 1px solid var(--border-light);
+  padding: 12px 16px;
+  background: var(--bg-main);
+}
+
+.chat-modal-input-wrapper {
+  display: flex;
+  align-items: flex-end;
+  gap: 10px;
+}
+
+.chat-modal-textarea {
+  flex: 1;
+  border: 1px solid var(--border-light);
+  border-radius: var(--radius-md);
+  padding: 10px 14px;
+  font-size: 14px;
+  font-family: inherit;
+  resize: none;
+  outline: none;
+  transition: border-color var(--transition-fast);
+}
+
+.chat-modal-textarea:focus {
+  border-color: var(--primary);
+}
+
+.chat-modal-textarea:disabled {
+  background: var(--bg-section);
+  cursor: not-allowed;
+}
+
+.chat-modal-send {
+  width: 42px;
+  height: 42px;
+  border: none;
+  border-radius: var(--radius-md);
+  background: var(--primary);
+  color: white;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition: background var(--transition-fast), transform var(--transition-fast);
+  flex-shrink: 0;
+}
+
+.chat-modal-send:hover:not(:disabled) {
+  background: var(--primary-hover);
+  transform: scale(1.05);
+}
+
+.chat-modal-send:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+@supports (padding: env(safe-area-inset-bottom)) {
+  .chat-modal-input {
+    padding-bottom: max(12px, env(safe-area-inset-bottom));
+  }
+}
+
+.psychologist-card__actions {
+  display: flex;
+  gap: 8px;
+  align-items: center;
+  flex-wrap: wrap;
+  margin-top: 8px;
+}
+
+.psychologist-card__slots-btn {
+  padding: 8px 14px;
+  background: var(--primary);
+  color: white;
+  border: none;
+  border-radius: var(--radius-md);
+  font-size: 13px;
+  font-weight: 500;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  transition: background var(--transition-fast);
+}
+
+.psychologist-card__slots-btn:hover:not(:disabled) {
+  background: var(--primary-hover);
+}
+
+.psychologist-card__slots-btn:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+@media (max-width: 640px) {
+  .chat-modal-overlay {
+    padding: 0;
+  }
+
+  .chat-modal-window {
+    max-width: 100%;
+    height: 100vh;
+    max-height: 100vh;
+    border-radius: 0;
+  }
+}
+
 /* === GLOBAL: Reduced Motion === */
 @media (prefers-reduced-motion: reduce) {
   *,


### PR DESCRIPTION
- Кнопка «Подобрать психолога» открывает чат-модалку (вместо перехода на /staff)
- ChatModal: AI-диалог через SignalR/REST + бронирование через Partner API
- Серверный proxy /api/partner/[...path] — ключ не утекает в клиент
- Кнопка «Показать слоты» на карточках психологов (Partner API slots)
- Бронирование через Partner API с адресом, ссылкой на встречу, реквизитами оплаты
- StaffHeader: добавлена кнопка «Подобрать психолога»
- CSS: стили модалки, fullscreen на мобильных, кнопка слотов